### PR TITLE
upgrade sveltekit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
         "@feltcoop/eslint-config": "^0.1.3",
         "@feltcoop/felt": "^0.22.1",
         "@feltcoop/gro": "^0.52.3",
-        "@sveltejs/adapter-static": "^1.0.0-next.22",
-        "@sveltejs/kit": "^1.0.0-next.203",
+        "@sveltejs/adapter-static": "^1.0.0-next.29",
+        "@sveltejs/kit": "^1.0.0-next.297",
         "@typescript-eslint/eslint-plugin": "^5.15.0",
         "@typescript-eslint/parser": "^5.15.0",
         "eslint": "^8.11.0",
@@ -268,21 +268,23 @@
       }
     },
     "node_modules/@sveltejs/adapter-static": {
-      "version": "1.0.0-next.22",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.22.tgz",
-      "integrity": "sha512-Dc1V9Z72dA7caVwNxxzl9Jhcq4uN9N1udA2GKNTLMu3aWX3Cq+v6C2CddY9Aazr+F9h6J0vi9AienuH+ySRXzQ==",
-      "dev": true
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.29.tgz",
+      "integrity": "sha512-0hjGnfT3BRyoHnzJ2w0/xL+xICRpKneDTm45ZzggiRrc0r71WJfF6toGeg8N4QUQnj8EJ3Itm453gsS1kt7VUQ==",
+      "dev": true,
+      "dependencies": {
+        "tiny-glob": "^0.2.9"
+      }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "1.0.0-next.203",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.203.tgz",
-      "integrity": "sha512-+bhfmkzquWMSCCFIJoh36U9D6IKC0p/NrIr4CBHMAdRpqzL9lMP0AYQm1fUDH20F/6b2tWvGxmEg+gAmHikRfA==",
+      "version": "1.0.0-next.297",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.297.tgz",
+      "integrity": "sha512-u2fQDMzPxz8gKreYRp7AYdWzlq0kdFeA/XAdKnsvvBirn2tAvo6OTJgIlMaKkflsQlUViDLWBLa/Kuw3bNYnPg==",
       "dev": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
-        "cheap-watch": "^1.0.4",
         "sade": "^1.7.4",
-        "vite": "^2.7.2"
+        "vite": "^2.8.0"
       },
       "bin": {
         "svelte-kit": "svelte-kit.js"
@@ -875,39 +877,60 @@
       "dev": true
     },
     "node_modules/esbuild": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.5.tgz",
-      "integrity": "sha512-ofwgH4ITPXhkMo2AM39oXpSe5KIyWjxicdqYVy+tLa1lMgxzPCKwaepcrSRtYbgTUMXwquxB1C3xQYpUNaPAFA==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.27.tgz",
+      "integrity": "sha512-MZQt5SywZS3hA9fXnMhR22dv0oPGh6QtjJRIYbgL1AeqAoQZE+Qn5ppGYQAoHv/vq827flj4tIJ79Mrdiwk46Q==",
       "dev": true,
       "hasInstallScript": true,
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
+      "engines": {
+        "node": ">=12"
+      },
       "optionalDependencies": {
-        "esbuild-android-arm64": "0.14.5",
-        "esbuild-darwin-64": "0.14.5",
-        "esbuild-darwin-arm64": "0.14.5",
-        "esbuild-freebsd-64": "0.14.5",
-        "esbuild-freebsd-arm64": "0.14.5",
-        "esbuild-linux-32": "0.14.5",
-        "esbuild-linux-64": "0.14.5",
-        "esbuild-linux-arm": "0.14.5",
-        "esbuild-linux-arm64": "0.14.5",
-        "esbuild-linux-mips64le": "0.14.5",
-        "esbuild-linux-ppc64le": "0.14.5",
-        "esbuild-netbsd-64": "0.14.5",
-        "esbuild-openbsd-64": "0.14.5",
-        "esbuild-sunos-64": "0.14.5",
-        "esbuild-windows-32": "0.14.5",
-        "esbuild-windows-64": "0.14.5",
-        "esbuild-windows-arm64": "0.14.5"
+        "esbuild-android-64": "0.14.27",
+        "esbuild-android-arm64": "0.14.27",
+        "esbuild-darwin-64": "0.14.27",
+        "esbuild-darwin-arm64": "0.14.27",
+        "esbuild-freebsd-64": "0.14.27",
+        "esbuild-freebsd-arm64": "0.14.27",
+        "esbuild-linux-32": "0.14.27",
+        "esbuild-linux-64": "0.14.27",
+        "esbuild-linux-arm": "0.14.27",
+        "esbuild-linux-arm64": "0.14.27",
+        "esbuild-linux-mips64le": "0.14.27",
+        "esbuild-linux-ppc64le": "0.14.27",
+        "esbuild-linux-riscv64": "0.14.27",
+        "esbuild-linux-s390x": "0.14.27",
+        "esbuild-netbsd-64": "0.14.27",
+        "esbuild-openbsd-64": "0.14.27",
+        "esbuild-sunos-64": "0.14.27",
+        "esbuild-windows-32": "0.14.27",
+        "esbuild-windows-64": "0.14.27",
+        "esbuild-windows-arm64": "0.14.27"
+      }
+    },
+    "node_modules/esbuild-android-64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.27.tgz",
+      "integrity": "sha512-LuEd4uPuj/16Y8j6kqy3Z2E9vNY9logfq8Tq+oTE2PZVuNs3M1kj5Qd4O95ee66yDGb3isaOCV7sOLDwtMfGaQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/esbuild-android-arm64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz",
-      "integrity": "sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.27.tgz",
+      "integrity": "sha512-E8Ktwwa6vX8q7QeJmg8yepBYXaee50OdQS3BFtEHKrzbV45H4foMOeEE7uqdjGQZFBap5VAqo7pvjlyA92wznQ==",
       "cpu": [
         "arm64"
       ],
@@ -915,12 +938,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-darwin-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz",
-      "integrity": "sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.27.tgz",
+      "integrity": "sha512-czw/kXl/1ZdenPWfw9jDc5iuIYxqUxgQ/Q+hRd4/3udyGGVI31r29LCViN2bAJgGvQkqyLGVcG03PJPEXQ5i2g==",
       "cpu": [
         "x64"
       ],
@@ -928,12 +954,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-darwin-arm64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz",
-      "integrity": "sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.27.tgz",
+      "integrity": "sha512-BEsv2U2U4o672oV8+xpXNxN9bgqRCtddQC6WBh4YhXKDcSZcdNh7+6nS+DM2vu7qWIWNA4JbRG24LUUYXysimQ==",
       "cpu": [
         "arm64"
       ],
@@ -941,12 +970,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-freebsd-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz",
-      "integrity": "sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.27.tgz",
+      "integrity": "sha512-7FeiFPGBo+ga+kOkDxtPmdPZdayrSzsV9pmfHxcyLKxu+3oTcajeZlOO1y9HW+t5aFZPiv7czOHM4KNd0tNwCA==",
       "cpu": [
         "x64"
       ],
@@ -954,12 +986,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz",
-      "integrity": "sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.27.tgz",
+      "integrity": "sha512-8CK3++foRZJluOWXpllG5zwAVlxtv36NpHfsbWS7TYlD8S+QruXltKlXToc/5ZNzBK++l6rvRKELu/puCLc7jA==",
       "cpu": [
         "arm64"
       ],
@@ -967,12 +1002,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-linux-32": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz",
-      "integrity": "sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.27.tgz",
+      "integrity": "sha512-qhNYIcT+EsYSBClZ5QhLzFzV5iVsP1YsITqblSaztr3+ZJUI+GoK8aXHyzKd7/CKKuK93cxEMJPpfi1dfsOfdw==",
       "cpu": [
         "ia32"
       ],
@@ -980,12 +1018,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-linux-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz",
-      "integrity": "sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.27.tgz",
+      "integrity": "sha512-ESjck9+EsHoTaKWlFKJpPZRN26uiav5gkI16RuI8WBxUdLrrAlYuYSndxxKgEn1csd968BX/8yQZATYf/9+/qg==",
       "cpu": [
         "x64"
       ],
@@ -993,12 +1034,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-linux-arm": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz",
-      "integrity": "sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.27.tgz",
+      "integrity": "sha512-JnnmgUBdqLQO9hoNZQqNHFWlNpSX82vzB3rYuCJMhtkuaWQEmQz6Lec1UIxJdC38ifEghNTBsF9bbe8dFilnCw==",
       "cpu": [
         "arm"
       ],
@@ -1006,12 +1050,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-linux-arm64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz",
-      "integrity": "sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.27.tgz",
+      "integrity": "sha512-no6Mi17eV2tHlJnqBHRLekpZ2/VYx+NfGxKcBE/2xOMYwctsanCaXxw4zapvNrGE9X38vefVXLz6YCF8b1EHiQ==",
       "cpu": [
         "arm64"
       ],
@@ -1019,12 +1066,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-linux-mips64le": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz",
-      "integrity": "sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.27.tgz",
+      "integrity": "sha512-NolWP2uOvIJpbwpsDbwfeExZOY1bZNlWE/kVfkzLMsSgqeVcl5YMen/cedRe9mKnpfLli+i0uSp7N+fkKNU27A==",
       "cpu": [
         "mips64el"
       ],
@@ -1032,12 +1082,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz",
-      "integrity": "sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.27.tgz",
+      "integrity": "sha512-/7dTjDvXMdRKmsSxKXeWyonuGgblnYDn0MI1xDC7J1VQXny8k1qgNp6VmrlsawwnsymSUUiThhkJsI+rx0taNA==",
       "cpu": [
         "ppc64"
       ],
@@ -1045,12 +1098,47 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-riscv64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.27.tgz",
+      "integrity": "sha512-D+aFiUzOJG13RhrSmZgrcFaF4UUHpqj7XSKrIiCXIj1dkIkFqdrmqMSOtSs78dOtObWiOrFCDDzB24UyeEiNGg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-s390x": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.27.tgz",
+      "integrity": "sha512-CD/D4tj0U4UQjELkdNlZhQ8nDHU5rBn6NGp47Hiz0Y7/akAY5i0oGadhEIg0WCY/HYVXFb3CsSPPwaKcTOW3bg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-netbsd-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz",
-      "integrity": "sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.27.tgz",
+      "integrity": "sha512-h3mAld69SrO1VoaMpYl3a5FNdGRE/Nqc+E8VtHOag4tyBwhCQXxtvDDOAKOUQexBGca0IuR6UayQ4ntSX5ij1Q==",
       "cpu": [
         "x64"
       ],
@@ -1058,12 +1146,15 @@
       "optional": true,
       "os": [
         "netbsd"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-openbsd-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz",
-      "integrity": "sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.27.tgz",
+      "integrity": "sha512-xwSje6qIZaDHXWoPpIgvL+7fC6WeubHHv18tusLYMwL+Z6bEa4Pbfs5IWDtQdHkArtfxEkIZz77944z8MgDxGw==",
       "cpu": [
         "x64"
       ],
@@ -1071,12 +1162,15 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-sunos-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz",
-      "integrity": "sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.27.tgz",
+      "integrity": "sha512-/nBVpWIDjYiyMhuqIqbXXsxBc58cBVH9uztAOIfWShStxq9BNBik92oPQPJ57nzWXRNKQUEFWr4Q98utDWz7jg==",
       "cpu": [
         "x64"
       ],
@@ -1084,12 +1178,15 @@
       "optional": true,
       "os": [
         "sunos"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-windows-32": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz",
-      "integrity": "sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.27.tgz",
+      "integrity": "sha512-Q9/zEjhZJ4trtWhFWIZvS/7RUzzi8rvkoaS9oiizkHTTKd8UxFwn/Mm2OywsAfYymgUYm8+y2b+BKTNEFxUekw==",
       "cpu": [
         "ia32"
       ],
@@ -1097,12 +1194,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-windows-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz",
-      "integrity": "sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.27.tgz",
+      "integrity": "sha512-b3y3vTSl5aEhWHK66ngtiS/c6byLf6y/ZBvODH1YkBM+MGtVL6jN38FdHUsZasCz9gFwYs/lJMVY9u7GL6wfYg==",
       "cpu": [
         "x64"
       ],
@@ -1110,249 +1210,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-windows-arm64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz",
-      "integrity": "sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/esbuild/node_modules/esbuild-android-arm64": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.5.tgz",
-      "integrity": "sha512-Sl6ysm7OAZZz+X3Mv3tOPhjMuSxNmztgoXH4ZZ3Yhbje5emEY6qiTnv3vBSljDlUl/yGaIjqC44qlj8s8G71xA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild/node_modules/esbuild-darwin-64": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.5.tgz",
-      "integrity": "sha512-VHZl23sM9BOZXcLxk1vTYls8TCAY+/3llw9vHKIWAHDHzBBOlVv26ORK8gnStNMqTjCSGSMoq4T5jOZf2WrJPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild/node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.5.tgz",
-      "integrity": "sha512-ugPOLgEQPoPLSqAFBajaczt+lcbUZR+V2fby3572h5jf/kFV6UL8LAZ1Ze58hcbKwfvbh4C09kp0PhqPgXKwOg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild/node_modules/esbuild-freebsd-64": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.5.tgz",
-      "integrity": "sha512-uP0yOixSHF505o/Kzq9e4bvZblCZp9GGx+a7enLOVSuvIvLmtj2yhZLRPGfbVNkPJXktTKNRAnNGkXHl53M6sw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild/node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.5.tgz",
-      "integrity": "sha512-M99NPu8hlirFo6Fgx0WfX6XxUFdGclUNv3MyyfDtTdNYbccMESwLSACGpE7HvJKWscdjaqajeMu2an9adGNfCw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild/node_modules/esbuild-linux-32": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.5.tgz",
-      "integrity": "sha512-hfqln4yb/jf/vPvI/A6aCvpIzqF3PdDmrKiikTohEUuRtvEZz234krtNwEAw5ssCue4NX8BJqrMpCTAHOl3LQw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild/node_modules/esbuild-linux-64": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.5.tgz",
-      "integrity": "sha512-T+OuYPlhytjj5DsvjUXizNjbV+/IrZiaDc9SNUfqiUOXHu0URFqchjhPVbBiBnWykCMJFB6pqNap2Oxth4iuYw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild/node_modules/esbuild-linux-arm": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.5.tgz",
-      "integrity": "sha512-5b10jKJ3lU4BUchOw9TgRResu8UZJf8qVjAzV5muHedonCfBzClGTT4KCNuOcLTJomH3wz6gNVJt1AxMglXnJg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild/node_modules/esbuild-linux-arm64": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.5.tgz",
-      "integrity": "sha512-ANOzoaH4kfbhEZT0EGY9g1tsZhDA+I0FRwBsj7D8pCU900pXF/l8YAOy5jWFQIb3vjG5+orFc5SqSzAKCisvTQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild/node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.5.tgz",
-      "integrity": "sha512-sSmGfOUNNB2Nd3tzp1RHSxiJmM5/RUIEP5aAtH+PpOP7FPp15Jcfwq7UNBJ82KLN3SJcwhUeEfcCaUFBzbTKxg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild/node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.5.tgz",
-      "integrity": "sha512-usfQrVVIQcpuc/U2NWc7/Ry+m622v+PjJ5eErNPdjWBPlcvD6kXaBTv94uQkVzZOHX3uYqprRrOjseed9ApSYA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild/node_modules/esbuild-netbsd-64": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.5.tgz",
-      "integrity": "sha512-Q5KpvPZcPnNEaTjrvuWqvEnlhI2jyi1wWwYunlEUAhx60spQOTy10sdYOA+s1M+LPb6kwvasrZZDmYyQlcVZeA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild/node_modules/esbuild-openbsd-64": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.5.tgz",
-      "integrity": "sha512-RZzRUu1RYKextJgXkHhAsuhLDvm73YP/wogpUG9MaAGvKTxnKAKRuaw2zJfnbz8iBqBQB2no2PmpVBNbqUTQrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild/node_modules/esbuild-sunos-64": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.5.tgz",
-      "integrity": "sha512-J2ffKsBBWscQlye+/giEgKsQCppwHHFqqt/sh+ojVF+DZy1ve6RpPGwXGcGF6IaZTAI9+Vk4eHleiQxb+PC9Yw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild/node_modules/esbuild-windows-32": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.5.tgz",
-      "integrity": "sha512-OTZvuAc1JBnwmeT+hR1+Vmgz6LOD7DggpnwtKMAExruSLxUMl02Z3pyalJ7zKh3gJ/KBRM1JQZLSk4/mFWijeQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild/node_modules/esbuild-windows-64": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.5.tgz",
-      "integrity": "sha512-ZM9rlBDsPEeMVJ1wcpNMXUad9VzYOFeOBUXBi+16HZTvFPy2DkcC2ZWcrByP3IESToD5lvHdjSX/w8rxphjqig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild/node_modules/esbuild-windows-arm64": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.5.tgz",
-      "integrity": "sha512-iK41mKG2LG0AKHE+9g/jDYU5ZQpJObt1uIPSGTiiiJKI5qbHdEck6Gaqq2tmBI933F2zB9yqZIX7IAdxwN/q4A==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.27.tgz",
+      "integrity": "sha512-I/reTxr6TFMcR5qbIkwRGvldMIaiBu2+MP0LlD7sOlNXrfqIl9uNjsuxFPGEG4IRomjfQ5q8WT+xlF/ySVkqKg==",
       "cpu": [
         "arm64"
       ],
@@ -1361,7 +1227,9 @@
       "os": [
         "win32"
       ],
-      "peer": true
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -1818,6 +1686,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true
+    },
     "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -1837,6 +1711,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
     },
     "node_modules/graceful-fs": {
       "version": "4.2.6",
@@ -1928,12 +1808,15 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -2158,9 +2041,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -2280,14 +2163,14 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
-      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+      "version": "8.4.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.8.tgz",
+      "integrity": "sha512-2tXEqGxrjvAO6U+CJzDL2Fk2kPHTv1jQsYkSoMeOis2SsYaXRO2COxTdQp99cYvif9JTXaAk9lYGc3VhJt7JPQ==",
       "dev": true,
       "dependencies": {
-        "nanoid": "^3.1.30",
+        "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.1"
+        "source-map-js": "^1.0.2"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -2397,13 +2280,20 @@
       "dev": true
     },
     "node_modules/resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.8.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-from": {
@@ -2569,9 +2459,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
-      "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2645,6 +2535,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/svelte": {
@@ -2778,6 +2680,16 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "node_modules/tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "dependencies": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2898,14 +2810,14 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.7.7.tgz",
-      "integrity": "sha512-Nm4ingl//gMSj/p1aCBHuTc5Fd8W8Mwdci/HUvqCVq8xaJqF7z08S/LRq1M9kS0jRfJk1/f/CwUyQAr6YgsOLw==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.8.6.tgz",
+      "integrity": "sha512-e4H0QpludOVKkmOsRyqQ7LTcMUDF3mcgyNU4lmi0B5JUbe0ZxeBBl8VoZ8Y6Rfn9eFKYtdXNPcYK97ZwH+K2ug==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.13.12",
-        "postcss": "^8.4.5",
-        "resolve": "^1.20.0",
+        "esbuild": "^0.14.14",
+        "postcss": "^8.4.6",
+        "resolve": "^1.22.0",
         "rollup": "^2.59.0"
       },
       "bin": {
@@ -2932,35 +2844,6 @@
         "stylus": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.15.tgz",
-      "integrity": "sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "optionalDependencies": {
-        "esbuild-android-arm64": "0.13.15",
-        "esbuild-darwin-64": "0.13.15",
-        "esbuild-darwin-arm64": "0.13.15",
-        "esbuild-freebsd-64": "0.13.15",
-        "esbuild-freebsd-arm64": "0.13.15",
-        "esbuild-linux-32": "0.13.15",
-        "esbuild-linux-64": "0.13.15",
-        "esbuild-linux-arm": "0.13.15",
-        "esbuild-linux-arm64": "0.13.15",
-        "esbuild-linux-mips64le": "0.13.15",
-        "esbuild-linux-ppc64le": "0.13.15",
-        "esbuild-netbsd-64": "0.13.15",
-        "esbuild-openbsd-64": "0.13.15",
-        "esbuild-sunos-64": "0.13.15",
-        "esbuild-windows-32": "0.13.15",
-        "esbuild-windows-64": "0.13.15",
-        "esbuild-windows-arm64": "0.13.15"
       }
     },
     "node_modules/which": {
@@ -3179,21 +3062,23 @@
       }
     },
     "@sveltejs/adapter-static": {
-      "version": "1.0.0-next.22",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.22.tgz",
-      "integrity": "sha512-Dc1V9Z72dA7caVwNxxzl9Jhcq4uN9N1udA2GKNTLMu3aWX3Cq+v6C2CddY9Aazr+F9h6J0vi9AienuH+ySRXzQ==",
-      "dev": true
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.29.tgz",
+      "integrity": "sha512-0hjGnfT3BRyoHnzJ2w0/xL+xICRpKneDTm45ZzggiRrc0r71WJfF6toGeg8N4QUQnj8EJ3Itm453gsS1kt7VUQ==",
+      "dev": true,
+      "requires": {
+        "tiny-glob": "^0.2.9"
+      }
     },
     "@sveltejs/kit": {
-      "version": "1.0.0-next.203",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.203.tgz",
-      "integrity": "sha512-+bhfmkzquWMSCCFIJoh36U9D6IKC0p/NrIr4CBHMAdRpqzL9lMP0AYQm1fUDH20F/6b2tWvGxmEg+gAmHikRfA==",
+      "version": "1.0.0-next.297",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.297.tgz",
+      "integrity": "sha512-u2fQDMzPxz8gKreYRp7AYdWzlq0kdFeA/XAdKnsvvBirn2tAvo6OTJgIlMaKkflsQlUViDLWBLa/Kuw3bNYnPg==",
       "dev": true,
       "requires": {
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
-        "cheap-watch": "^1.0.4",
         "sade": "^1.7.4",
-        "vite": "^2.7.2"
+        "vite": "^2.8.0"
       }
     },
     "@sveltejs/vite-plugin-svelte": {
@@ -3593,285 +3478,170 @@
       "dev": true
     },
     "esbuild": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.5.tgz",
-      "integrity": "sha512-ofwgH4ITPXhkMo2AM39oXpSe5KIyWjxicdqYVy+tLa1lMgxzPCKwaepcrSRtYbgTUMXwquxB1C3xQYpUNaPAFA==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.27.tgz",
+      "integrity": "sha512-MZQt5SywZS3hA9fXnMhR22dv0oPGh6QtjJRIYbgL1AeqAoQZE+Qn5ppGYQAoHv/vq827flj4tIJ79Mrdiwk46Q==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "esbuild-android-arm64": "0.14.5",
-        "esbuild-darwin-64": "0.14.5",
-        "esbuild-darwin-arm64": "0.14.5",
-        "esbuild-freebsd-64": "0.14.5",
-        "esbuild-freebsd-arm64": "0.14.5",
-        "esbuild-linux-32": "0.14.5",
-        "esbuild-linux-64": "0.14.5",
-        "esbuild-linux-arm": "0.14.5",
-        "esbuild-linux-arm64": "0.14.5",
-        "esbuild-linux-mips64le": "0.14.5",
-        "esbuild-linux-ppc64le": "0.14.5",
-        "esbuild-netbsd-64": "0.14.5",
-        "esbuild-openbsd-64": "0.14.5",
-        "esbuild-sunos-64": "0.14.5",
-        "esbuild-windows-32": "0.14.5",
-        "esbuild-windows-64": "0.14.5",
-        "esbuild-windows-arm64": "0.14.5"
-      },
-      "dependencies": {
-        "esbuild-android-arm64": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.5.tgz",
-          "integrity": "sha512-Sl6ysm7OAZZz+X3Mv3tOPhjMuSxNmztgoXH4ZZ3Yhbje5emEY6qiTnv3vBSljDlUl/yGaIjqC44qlj8s8G71xA==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "esbuild-darwin-64": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.5.tgz",
-          "integrity": "sha512-VHZl23sM9BOZXcLxk1vTYls8TCAY+/3llw9vHKIWAHDHzBBOlVv26ORK8gnStNMqTjCSGSMoq4T5jOZf2WrJPQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "esbuild-darwin-arm64": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.5.tgz",
-          "integrity": "sha512-ugPOLgEQPoPLSqAFBajaczt+lcbUZR+V2fby3572h5jf/kFV6UL8LAZ1Ze58hcbKwfvbh4C09kp0PhqPgXKwOg==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "esbuild-freebsd-64": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.5.tgz",
-          "integrity": "sha512-uP0yOixSHF505o/Kzq9e4bvZblCZp9GGx+a7enLOVSuvIvLmtj2yhZLRPGfbVNkPJXktTKNRAnNGkXHl53M6sw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "esbuild-freebsd-arm64": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.5.tgz",
-          "integrity": "sha512-M99NPu8hlirFo6Fgx0WfX6XxUFdGclUNv3MyyfDtTdNYbccMESwLSACGpE7HvJKWscdjaqajeMu2an9adGNfCw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "esbuild-linux-32": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.5.tgz",
-          "integrity": "sha512-hfqln4yb/jf/vPvI/A6aCvpIzqF3PdDmrKiikTohEUuRtvEZz234krtNwEAw5ssCue4NX8BJqrMpCTAHOl3LQw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "esbuild-linux-64": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.5.tgz",
-          "integrity": "sha512-T+OuYPlhytjj5DsvjUXizNjbV+/IrZiaDc9SNUfqiUOXHu0URFqchjhPVbBiBnWykCMJFB6pqNap2Oxth4iuYw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "esbuild-linux-arm": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.5.tgz",
-          "integrity": "sha512-5b10jKJ3lU4BUchOw9TgRResu8UZJf8qVjAzV5muHedonCfBzClGTT4KCNuOcLTJomH3wz6gNVJt1AxMglXnJg==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "esbuild-linux-arm64": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.5.tgz",
-          "integrity": "sha512-ANOzoaH4kfbhEZT0EGY9g1tsZhDA+I0FRwBsj7D8pCU900pXF/l8YAOy5jWFQIb3vjG5+orFc5SqSzAKCisvTQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "esbuild-linux-mips64le": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.5.tgz",
-          "integrity": "sha512-sSmGfOUNNB2Nd3tzp1RHSxiJmM5/RUIEP5aAtH+PpOP7FPp15Jcfwq7UNBJ82KLN3SJcwhUeEfcCaUFBzbTKxg==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "esbuild-linux-ppc64le": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.5.tgz",
-          "integrity": "sha512-usfQrVVIQcpuc/U2NWc7/Ry+m622v+PjJ5eErNPdjWBPlcvD6kXaBTv94uQkVzZOHX3uYqprRrOjseed9ApSYA==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "esbuild-netbsd-64": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.5.tgz",
-          "integrity": "sha512-Q5KpvPZcPnNEaTjrvuWqvEnlhI2jyi1wWwYunlEUAhx60spQOTy10sdYOA+s1M+LPb6kwvasrZZDmYyQlcVZeA==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "esbuild-openbsd-64": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.5.tgz",
-          "integrity": "sha512-RZzRUu1RYKextJgXkHhAsuhLDvm73YP/wogpUG9MaAGvKTxnKAKRuaw2zJfnbz8iBqBQB2no2PmpVBNbqUTQrw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "esbuild-sunos-64": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.5.tgz",
-          "integrity": "sha512-J2ffKsBBWscQlye+/giEgKsQCppwHHFqqt/sh+ojVF+DZy1ve6RpPGwXGcGF6IaZTAI9+Vk4eHleiQxb+PC9Yw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "esbuild-windows-32": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.5.tgz",
-          "integrity": "sha512-OTZvuAc1JBnwmeT+hR1+Vmgz6LOD7DggpnwtKMAExruSLxUMl02Z3pyalJ7zKh3gJ/KBRM1JQZLSk4/mFWijeQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "esbuild-windows-64": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.5.tgz",
-          "integrity": "sha512-ZM9rlBDsPEeMVJ1wcpNMXUad9VzYOFeOBUXBi+16HZTvFPy2DkcC2ZWcrByP3IESToD5lvHdjSX/w8rxphjqig==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "esbuild-windows-arm64": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.5.tgz",
-          "integrity": "sha512-iK41mKG2LG0AKHE+9g/jDYU5ZQpJObt1uIPSGTiiiJKI5qbHdEck6Gaqq2tmBI933F2zB9yqZIX7IAdxwN/q4A==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        }
+        "esbuild-android-64": "0.14.27",
+        "esbuild-android-arm64": "0.14.27",
+        "esbuild-darwin-64": "0.14.27",
+        "esbuild-darwin-arm64": "0.14.27",
+        "esbuild-freebsd-64": "0.14.27",
+        "esbuild-freebsd-arm64": "0.14.27",
+        "esbuild-linux-32": "0.14.27",
+        "esbuild-linux-64": "0.14.27",
+        "esbuild-linux-arm": "0.14.27",
+        "esbuild-linux-arm64": "0.14.27",
+        "esbuild-linux-mips64le": "0.14.27",
+        "esbuild-linux-ppc64le": "0.14.27",
+        "esbuild-linux-riscv64": "0.14.27",
+        "esbuild-linux-s390x": "0.14.27",
+        "esbuild-netbsd-64": "0.14.27",
+        "esbuild-openbsd-64": "0.14.27",
+        "esbuild-sunos-64": "0.14.27",
+        "esbuild-windows-32": "0.14.27",
+        "esbuild-windows-64": "0.14.27",
+        "esbuild-windows-arm64": "0.14.27"
       }
     },
+    "esbuild-android-64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.27.tgz",
+      "integrity": "sha512-LuEd4uPuj/16Y8j6kqy3Z2E9vNY9logfq8Tq+oTE2PZVuNs3M1kj5Qd4O95ee66yDGb3isaOCV7sOLDwtMfGaQ==",
+      "dev": true,
+      "optional": true
+    },
     "esbuild-android-arm64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz",
-      "integrity": "sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.27.tgz",
+      "integrity": "sha512-E8Ktwwa6vX8q7QeJmg8yepBYXaee50OdQS3BFtEHKrzbV45H4foMOeEE7uqdjGQZFBap5VAqo7pvjlyA92wznQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz",
-      "integrity": "sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.27.tgz",
+      "integrity": "sha512-czw/kXl/1ZdenPWfw9jDc5iuIYxqUxgQ/Q+hRd4/3udyGGVI31r29LCViN2bAJgGvQkqyLGVcG03PJPEXQ5i2g==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-arm64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz",
-      "integrity": "sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.27.tgz",
+      "integrity": "sha512-BEsv2U2U4o672oV8+xpXNxN9bgqRCtddQC6WBh4YhXKDcSZcdNh7+6nS+DM2vu7qWIWNA4JbRG24LUUYXysimQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz",
-      "integrity": "sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.27.tgz",
+      "integrity": "sha512-7FeiFPGBo+ga+kOkDxtPmdPZdayrSzsV9pmfHxcyLKxu+3oTcajeZlOO1y9HW+t5aFZPiv7czOHM4KNd0tNwCA==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-arm64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz",
-      "integrity": "sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.27.tgz",
+      "integrity": "sha512-8CK3++foRZJluOWXpllG5zwAVlxtv36NpHfsbWS7TYlD8S+QruXltKlXToc/5ZNzBK++l6rvRKELu/puCLc7jA==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-32": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz",
-      "integrity": "sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.27.tgz",
+      "integrity": "sha512-qhNYIcT+EsYSBClZ5QhLzFzV5iVsP1YsITqblSaztr3+ZJUI+GoK8aXHyzKd7/CKKuK93cxEMJPpfi1dfsOfdw==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz",
-      "integrity": "sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.27.tgz",
+      "integrity": "sha512-ESjck9+EsHoTaKWlFKJpPZRN26uiav5gkI16RuI8WBxUdLrrAlYuYSndxxKgEn1csd968BX/8yQZATYf/9+/qg==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz",
-      "integrity": "sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.27.tgz",
+      "integrity": "sha512-JnnmgUBdqLQO9hoNZQqNHFWlNpSX82vzB3rYuCJMhtkuaWQEmQz6Lec1UIxJdC38ifEghNTBsF9bbe8dFilnCw==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz",
-      "integrity": "sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.27.tgz",
+      "integrity": "sha512-no6Mi17eV2tHlJnqBHRLekpZ2/VYx+NfGxKcBE/2xOMYwctsanCaXxw4zapvNrGE9X38vefVXLz6YCF8b1EHiQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-mips64le": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz",
-      "integrity": "sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.27.tgz",
+      "integrity": "sha512-NolWP2uOvIJpbwpsDbwfeExZOY1bZNlWE/kVfkzLMsSgqeVcl5YMen/cedRe9mKnpfLli+i0uSp7N+fkKNU27A==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-ppc64le": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz",
-      "integrity": "sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.27.tgz",
+      "integrity": "sha512-/7dTjDvXMdRKmsSxKXeWyonuGgblnYDn0MI1xDC7J1VQXny8k1qgNp6VmrlsawwnsymSUUiThhkJsI+rx0taNA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-riscv64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.27.tgz",
+      "integrity": "sha512-D+aFiUzOJG13RhrSmZgrcFaF4UUHpqj7XSKrIiCXIj1dkIkFqdrmqMSOtSs78dOtObWiOrFCDDzB24UyeEiNGg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-s390x": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.27.tgz",
+      "integrity": "sha512-CD/D4tj0U4UQjELkdNlZhQ8nDHU5rBn6NGp47Hiz0Y7/akAY5i0oGadhEIg0WCY/HYVXFb3CsSPPwaKcTOW3bg==",
       "dev": true,
       "optional": true
     },
     "esbuild-netbsd-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz",
-      "integrity": "sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.27.tgz",
+      "integrity": "sha512-h3mAld69SrO1VoaMpYl3a5FNdGRE/Nqc+E8VtHOag4tyBwhCQXxtvDDOAKOUQexBGca0IuR6UayQ4ntSX5ij1Q==",
       "dev": true,
       "optional": true
     },
     "esbuild-openbsd-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz",
-      "integrity": "sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.27.tgz",
+      "integrity": "sha512-xwSje6qIZaDHXWoPpIgvL+7fC6WeubHHv18tusLYMwL+Z6bEa4Pbfs5IWDtQdHkArtfxEkIZz77944z8MgDxGw==",
       "dev": true,
       "optional": true
     },
     "esbuild-sunos-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz",
-      "integrity": "sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.27.tgz",
+      "integrity": "sha512-/nBVpWIDjYiyMhuqIqbXXsxBc58cBVH9uztAOIfWShStxq9BNBik92oPQPJ57nzWXRNKQUEFWr4Q98utDWz7jg==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-32": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz",
-      "integrity": "sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.27.tgz",
+      "integrity": "sha512-Q9/zEjhZJ4trtWhFWIZvS/7RUzzi8rvkoaS9oiizkHTTKd8UxFwn/Mm2OywsAfYymgUYm8+y2b+BKTNEFxUekw==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz",
-      "integrity": "sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.27.tgz",
+      "integrity": "sha512-b3y3vTSl5aEhWHK66ngtiS/c6byLf6y/ZBvODH1YkBM+MGtVL6jN38FdHUsZasCz9gFwYs/lJMVY9u7GL6wfYg==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-arm64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz",
-      "integrity": "sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.27.tgz",
+      "integrity": "sha512-I/reTxr6TFMcR5qbIkwRGvldMIaiBu2+MP0LlD7sOlNXrfqIl9uNjsuxFPGEG4IRomjfQ5q8WT+xlF/ySVkqKg==",
       "dev": true,
       "optional": true
     },
@@ -4225,6 +3995,12 @@
         "type-fest": "^0.20.2"
       }
     },
+    "globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true
+    },
     "globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -4238,6 +4014,12 @@
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
+    },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.6",
@@ -4308,9 +4090,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -4494,9 +4276,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true
     },
     "natural-compare": {
@@ -4586,14 +4368,14 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
-      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+      "version": "8.4.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.8.tgz",
+      "integrity": "sha512-2tXEqGxrjvAO6U+CJzDL2Fk2kPHTv1jQsYkSoMeOis2SsYaXRO2COxTdQp99cYvif9JTXaAk9lYGc3VhJt7JPQ==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.1.30",
+        "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.1"
+        "source-map-js": "^1.0.2"
       }
     },
     "prelude-ls": {
@@ -4655,13 +4437,14 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.8.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
     "resolve-from": {
@@ -4773,9 +4556,9 @@
       "dev": true
     },
     "source-map-js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
-      "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
     },
     "source-map-support": {
@@ -4832,6 +4615,12 @@
       "requires": {
         "has-flag": "^4.0.0"
       }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
     },
     "svelte": {
       "version": "3.46.4",
@@ -4896,6 +4685,16 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "requires": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -4985,43 +4784,16 @@
       "dev": true
     },
     "vite": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.7.7.tgz",
-      "integrity": "sha512-Nm4ingl//gMSj/p1aCBHuTc5Fd8W8Mwdci/HUvqCVq8xaJqF7z08S/LRq1M9kS0jRfJk1/f/CwUyQAr6YgsOLw==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.8.6.tgz",
+      "integrity": "sha512-e4H0QpludOVKkmOsRyqQ7LTcMUDF3mcgyNU4lmi0B5JUbe0ZxeBBl8VoZ8Y6Rfn9eFKYtdXNPcYK97ZwH+K2ug==",
       "dev": true,
       "requires": {
-        "esbuild": "^0.13.12",
+        "esbuild": "^0.14.14",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.5",
-        "resolve": "^1.20.0",
+        "postcss": "^8.4.6",
+        "resolve": "^1.22.0",
         "rollup": "^2.59.0"
-      },
-      "dependencies": {
-        "esbuild": {
-          "version": "0.13.15",
-          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.15.tgz",
-          "integrity": "sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==",
-          "dev": true,
-          "requires": {
-            "esbuild-android-arm64": "0.13.15",
-            "esbuild-darwin-64": "0.13.15",
-            "esbuild-darwin-arm64": "0.13.15",
-            "esbuild-freebsd-64": "0.13.15",
-            "esbuild-freebsd-arm64": "0.13.15",
-            "esbuild-linux-32": "0.13.15",
-            "esbuild-linux-64": "0.13.15",
-            "esbuild-linux-arm": "0.13.15",
-            "esbuild-linux-arm64": "0.13.15",
-            "esbuild-linux-mips64le": "0.13.15",
-            "esbuild-linux-ppc64le": "0.13.15",
-            "esbuild-netbsd-64": "0.13.15",
-            "esbuild-openbsd-64": "0.13.15",
-            "esbuild-sunos-64": "0.13.15",
-            "esbuild-windows-32": "0.13.15",
-            "esbuild-windows-64": "0.13.15",
-            "esbuild-windows-arm64": "0.13.15"
-          }
-        }
       }
     },
     "which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@feltcoop/eslint-config": "^0.1.3",
         "@feltcoop/felt": "^0.22.1",
-        "@feltcoop/gro": "^0.52.3",
+        "@feltcoop/gro": "^0.53.0",
         "@sveltejs/adapter-static": "^1.0.0-next.29",
         "@sveltejs/kit": "^1.0.0-next.297",
         "@typescript-eslint/eslint-plugin": "^5.15.0",
@@ -117,24 +117,24 @@
       }
     },
     "node_modules/@feltcoop/gro": {
-      "version": "0.52.3",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.52.3.tgz",
-      "integrity": "sha512-nOMjEJxDssJ/TlEy5jg6t8R50v8pqnik9vZ0u8Nst6YHH/zL+tsYIg7WJAy6+VEiGLb3vkCZFTfMCAhR9SS4Qw==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.53.0.tgz",
+      "integrity": "sha512-M7/kMewIMJJ4smZA5HVLlI4bHXlh8EORrTUTWgE/gFtP++aenZiHKAfl97bWtIdL4Bl5A9FYt+38ZQykJ97B1A==",
       "dev": true,
       "dependencies": {
-        "@rollup/pluginutils": "^4.1.2",
+        "@rollup/pluginutils": "^4.2.0",
         "@ryanatkn/json-schema-to-typescript": "^11.1.2",
         "@types/source-map-support": "^0.5.4",
         "ajv": "^8.10.0",
         "cheap-watch": "^1.0.4",
         "dequal": "^2.0.2",
-        "es-module-lexer": "^0.9.3",
-        "fs-extra": "^10.0.0",
+        "es-module-lexer": "^0.10.0",
+        "fs-extra": "^10.0.1",
         "kleur": "^4.1.4",
         "mri": "^1.2.0",
         "path-browserify": "^1.0.1",
         "prettier": "^2.5.1",
-        "prettier-plugin-svelte": "^2.5.1",
+        "prettier-plugin-svelte": "^2.6.0",
         "source-map-support": "^0.5.20",
         "sourcemap-codec": "^1.4.8",
         "strict-event-emitter-types": "^2.0.0",
@@ -148,7 +148,7 @@
       },
       "peerDependencies": {
         "@feltcoop/felt": ">=0.22.1",
-        "@sveltejs/kit": ">=1.0.0-next.203",
+        "@sveltejs/kit": ">=1.0.0-next.298",
         "esbuild": ">=0.14.0",
         "svelte": ">=3.44.0",
         "svelte-preprocess-esbuild": ">=2.0.0",
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
-      "integrity": "sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.0.tgz",
+      "integrity": "sha512-2WUyJNRkyH5p487pGnn4tWAsxhEFKN/pT8CMgHshd5H+IXkOnKvKZwsz5ZWz+YCXkleZRAU5kwbfgF8CPfDRqA==",
       "dev": true,
       "dependencies": {
         "estree-walker": "^2.0.1",
@@ -277,9 +277,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "1.0.0-next.297",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.297.tgz",
-      "integrity": "sha512-u2fQDMzPxz8gKreYRp7AYdWzlq0kdFeA/XAdKnsvvBirn2tAvo6OTJgIlMaKkflsQlUViDLWBLa/Kuw3bNYnPg==",
+      "version": "1.0.0-next.298",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.298.tgz",
+      "integrity": "sha512-HUna2KgBc9NdeSCAqZBo6NUuRHab1tRMW6O3OtLvPs7ldSY+cEarDmUJb1ZeHwPrbcS2RTHSnBNNc0l+UyiFIw==",
       "dev": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
@@ -865,9 +865,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.10.0.tgz",
+      "integrity": "sha512-0fHYovx7ETE13wPL8zG/V+ElEgSeSwsgRVOvNZ+g/Y/2YyJq75+IEY4ZBr59vUZ3Voci1jBIktwpj8oODaWa+g==",
       "dev": true
     },
     "node_modules/es6-promise": {
@@ -1595,9 +1595,9 @@
       "dev": true
     },
     "node_modules/fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -2950,24 +2950,24 @@
       }
     },
     "@feltcoop/gro": {
-      "version": "0.52.3",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.52.3.tgz",
-      "integrity": "sha512-nOMjEJxDssJ/TlEy5jg6t8R50v8pqnik9vZ0u8Nst6YHH/zL+tsYIg7WJAy6+VEiGLb3vkCZFTfMCAhR9SS4Qw==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.53.0.tgz",
+      "integrity": "sha512-M7/kMewIMJJ4smZA5HVLlI4bHXlh8EORrTUTWgE/gFtP++aenZiHKAfl97bWtIdL4Bl5A9FYt+38ZQykJ97B1A==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^4.1.2",
+        "@rollup/pluginutils": "^4.2.0",
         "@ryanatkn/json-schema-to-typescript": "^11.1.2",
         "@types/source-map-support": "^0.5.4",
         "ajv": "^8.10.0",
         "cheap-watch": "^1.0.4",
         "dequal": "^2.0.2",
-        "es-module-lexer": "^0.9.3",
-        "fs-extra": "^10.0.0",
+        "es-module-lexer": "^0.10.0",
+        "fs-extra": "^10.0.1",
         "kleur": "^4.1.4",
         "mri": "^1.2.0",
         "path-browserify": "^1.0.1",
         "prettier": "^2.5.1",
-        "prettier-plugin-svelte": "^2.5.1",
+        "prettier-plugin-svelte": "^2.6.0",
         "source-map-support": "^0.5.20",
         "sourcemap-codec": "^1.4.8",
         "strict-event-emitter-types": "^2.0.0",
@@ -3039,9 +3039,9 @@
       }
     },
     "@rollup/pluginutils": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
-      "integrity": "sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.0.tgz",
+      "integrity": "sha512-2WUyJNRkyH5p487pGnn4tWAsxhEFKN/pT8CMgHshd5H+IXkOnKvKZwsz5ZWz+YCXkleZRAU5kwbfgF8CPfDRqA==",
       "dev": true,
       "requires": {
         "estree-walker": "^2.0.1",
@@ -3071,9 +3071,9 @@
       }
     },
     "@sveltejs/kit": {
-      "version": "1.0.0-next.297",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.297.tgz",
-      "integrity": "sha512-u2fQDMzPxz8gKreYRp7AYdWzlq0kdFeA/XAdKnsvvBirn2tAvo6OTJgIlMaKkflsQlUViDLWBLa/Kuw3bNYnPg==",
+      "version": "1.0.0-next.298",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.298.tgz",
+      "integrity": "sha512-HUna2KgBc9NdeSCAqZBo6NUuRHab1tRMW6O3OtLvPs7ldSY+cEarDmUJb1ZeHwPrbcS2RTHSnBNNc0l+UyiFIw==",
       "dev": true,
       "requires": {
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
@@ -3466,9 +3466,9 @@
       }
     },
     "es-module-lexer": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.10.0.tgz",
+      "integrity": "sha512-0fHYovx7ETE13wPL8zG/V+ElEgSeSwsgRVOvNZ+g/Y/2YyJq75+IEY4ZBr59vUZ3Voci1jBIktwpj8oODaWa+g==",
       "dev": true
     },
     "es6-promise": {
@@ -3928,9 +3928,9 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@feltcoop/eslint-config": "^0.1.3",
     "@feltcoop/felt": "^0.22.1",
-    "@feltcoop/gro": "^0.52.3",
+    "@feltcoop/gro": "^0.53.0",
     "@sveltejs/adapter-static": "^1.0.0-next.29",
     "@sveltejs/kit": "^1.0.0-next.297",
     "@typescript-eslint/eslint-plugin": "^5.15.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "@feltcoop/eslint-config": "^0.1.3",
     "@feltcoop/felt": "^0.22.1",
     "@feltcoop/gro": "^0.52.3",
-    "@sveltejs/adapter-static": "^1.0.0-next.22",
-    "@sveltejs/kit": "^1.0.0-next.203",
+    "@sveltejs/adapter-static": "^1.0.0-next.29",
+    "@sveltejs/kit": "^1.0.0-next.297",
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",
     "eslint": "^8.11.0",
@@ -33,7 +33,10 @@
   },
   "eslintConfig": {
     "root": true,
-    "extends": "@feltcoop"
+    "extends": "@feltcoop",
+    "ignorePatterns": [
+      "svelte.config.js"
+    ]
   },
   "prettier": {
     "useTabs": true,

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,1 +1,0 @@
-import '@sveltejs/kit';

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -15,6 +15,9 @@ export default {
 		files: {assets: 'src/static'},
 		prerender: {default: true},
 		vite: {
+			ssr: {
+				noExternal: ['@feltcoop/felt'],
+			},
 			optimizeDeps: {
 				exclude: ['@feltcoop/felt'],
 			},

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -18,9 +18,6 @@ export default {
 			ssr: {
 				noExternal: ['@feltcoop/felt'],
 			},
-			optimizeDeps: {
-				exclude: ['@feltcoop/felt'],
-			},
 		},
 	},
 };

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -13,10 +13,8 @@ export default {
 		adapter: static_adapter(),
 		paths: dev ? undefined : {base: '/felt-template'}, // for GitHub pages -- delete this line for top-level domains
 		files: {assets: 'src/static'},
+		prerender: {default: true},
 		vite: {
-			ssr: {
-				noExternal: ['@feltcoop/felt'],
-			},
 			optimizeDeps: {
 				exclude: ['@feltcoop/felt'],
 			},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
+		"types": ["@sveltejs/kit"],
 		"strict": true,
 		"useUnknownInCatchVariables": false,
 		"exactOptionalPropertyTypes": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,30 +1,15 @@
 {
-	"include": ["src"],
+	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
-		"moduleResolution": "node",
-		"target": "es2020",
-		"module": "esnext",
-		"lib": ["esnext", "dom"],
 		"strict": true,
 		"useUnknownInCatchVariables": false,
 		"exactOptionalPropertyTypes": false,
-		"forceConsistentCasingInFileNames": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noImplicitReturns": true,
 		"noImplicitOverride": true,
 		"noFallthroughCasesInSwitch": true,
-		"isolatedModules": true,
-		"preserveValueImports": true,
-		"importsNotUsedAsValues": "remove",
-		"resolveJsonModule": true,
-		"sourceMap": true,
 		"importHelpers": true,
-		"esModuleInterop": true,
-		"skipLibCheck": true,
-		"checkJs": true,
-		"paths": {
-			"$lib/*": ["./src/lib/*"]
-		}
+		"preserveValueImports": true
 	}
 }


### PR DESCRIPTION
Upgrades SveteKit, but there are some quirks, some of which we should be able to fix in the future:

- `preserveValueImports` is duplicated in `tsconfig.json` because `svelte-preprocess-esbuild` currently doesn't merge extended configs or set the value directly -- this PR will allow us to remove us: https://github.com/lukeed/svelte-preprocess-esbuild/ pull/7
- `svelte.config.js` isn't included in `tsconfig.json`, so ESLint shows an error when it's opened; rather than overriding SvelteKit's `include` in `tsconfig.json`, or just letting the error remain, we're currently ignoring the file with `ignorePatterns` in `package.json`. It seems better to lint the file, but I'd prefer not to override SvelteKit.
- the SvelteKit config sets `importsNotUsedAsValues` to `error` so we need to use `import type` instead of inline type imports for import statements with no value imports

todo:

- [x] run `svelte-kit sync` for `gro check` and `gro typecheck` and upgrade Gro

In a followup I'll see if our Vite config overrides are still needed, or if they can be fixed on our end.
